### PR TITLE
Include dataQueue in response to unsubscribe request

### DIFF
--- a/metricq_manager/manager.py
+++ b/metricq_manager/manager.py
@@ -194,7 +194,7 @@ class Manager(Agent):
             raise Exception("queue already timed out")
 
         self.event_loop.call_soon(channel.close)
-        return {'dataServerAddress': self.data_url_credentialfree}
+        return {'dataServerAddress': self.data_url_credentialfree, 'dataQueue': queue_name}
 
     @rpc_handler('release', 'sink.release')
     async def handle_release(self, from_token, **body):


### PR DESCRIPTION
Stateless connections (e.g. the C++ metricq::simple API) need to have
their data queue included when unsubscribing in order to be configured
correctly.