### PR TITLE
Move parts of metricq-manager to new management baseclass

### DIFF
--- a/metricq_manager/__init__.py
+++ b/metricq_manager/__init__.py
@@ -19,4 +19,4 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with metricq.  If not, see <http://www.gnu.org/licenses/>.
-from .manager import manager_cmd
+from .cmd import manager_cmd

--- a/metricq_manager/cmd.py
+++ b/metricq_manager/cmd.py
@@ -1,0 +1,90 @@
+# metricq
+# Copyright (C) 2018 ZIH, Technische Universitaet Dresden, Federal Republic of Germany
+#
+# All rights reserved.
+#
+# This file is part of metricq.
+#
+# metricq is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# metricq is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with metricq.  If not, see <http://www.gnu.org/licenses/>.
+import logging
+
+import click
+
+import aiomonitor
+import click_completion
+import click_log
+from metricq.logging import get_logger
+
+from .manager import Manager
+
+logger = get_logger()
+
+click_log.basic_config(logger)
+logger.setLevel("INFO")
+# Use this if we ever use threads
+# logger.handlers[0].formatter = logging.Formatter(fmt='%(asctime)s %(threadName)-16s %(levelname)-8s %(message)s')
+logger.handlers[0].formatter = logging.Formatter(
+    fmt="%(asctime)s [%(levelname)-8s] [%(name)-20s] %(message)s"
+)
+
+click_completion.init()
+
+
+@click.command()
+@click.argument("rpc-url", default="amqp://localhost/")
+@click.argument("data-url", default="amqp://localhost:5672/")
+@click.option("--queue-ttl", default=30 * 60 * 1000)
+@click.option(
+    "--config-path",
+    default=".",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+)
+@click.option("--monitor/--no-monitor", default=True)
+@click.option("--couchdb-url", default="http://127.0.0.1:5984")
+@click.option("--couchdb-user", default="admin")
+@click.option("--couchdb-password", default="admin")
+@click.option("--log-to-journal/--no-log-to-journal", default=False)
+@click_log.simple_verbosity_option(logger)
+def manager_cmd(
+    rpc_url,
+    data_url,
+    config_path,
+    queue_ttl,
+    monitor,
+    couchdb_url,
+    couchdb_user,
+    couchdb_password,
+    log_to_journal,
+):
+    if log_to_journal:
+        try:
+            from systemd import journal
+
+            logger.handlers[0] = journal.JournaldLogHandler()
+        except ImportError:
+            logger.error("Can't enable journal logger, systemd package not found!")
+    manager = Manager(
+        rpc_url,
+        data_url,
+        config_path,
+        queue_ttl,
+        couchdb_url,
+        couchdb_user,
+        couchdb_password,
+    )
+    if monitor:
+        with aiomonitor.start_monitor(manager.event_loop, locals={"manager": manager}):
+            manager.run()
+    else:
+        manager.run()

--- a/metricq_manager/manager.py
+++ b/metricq_manager/manager.py
@@ -64,7 +64,12 @@ class Manager(ManagementAgent):
         couchdb_password,
     ):
         super().__init__(
-            "manager", management_url, couchdb_url, couchdb_user, couchdb_password
+            "manager",
+            management_url,
+            config_path,
+            couchdb_url,
+            couchdb_user,
+            couchdb_password,
         )
 
         self.management_queue_name = "management"

--- a/metricq_manager/manager.py
+++ b/metricq_manager/manager.py
@@ -35,7 +35,7 @@ import aiomonitor
 import click_completion
 import click_log
 from aiocouch import CouchDB
-from metricq import Agent, rpc_handler
+from metricq import ManagementAgent, rpc_handler
 from metricq.logging import get_logger
 from yarl import URL
 
@@ -52,7 +52,7 @@ logger.handlers[0].formatter = logging.Formatter(
 click_completion.init()
 
 
-class Manager(Agent):
+class Manager(ManagementAgent):
     def __init__(
         self,
         management_url,
@@ -63,7 +63,9 @@ class Manager(Agent):
         couchdb_user,
         couchdb_password,
     ):
-        super().__init__("manager", management_url)
+        super().__init__(
+            "manager", management_url, couchdb_url, couchdb_user, couchdb_password
+        )
 
         self.management_queue_name = "management"
         self.management_queue = None
@@ -96,15 +98,6 @@ class Manager(Agent):
 
         self.config_path = config_path
         self.queue_ttl = queue_ttl
-
-        self.couchdb_client = CouchDB(
-            couchdb_url,
-            user=couchdb_user,
-            password=couchdb_password,
-            loop=self.event_loop,
-        )
-        self.couchdb_db_config = None
-        self.couchdb_db_metadata = None
 
         # TODO if this proves to be reliable, remove the option
         self._subscription_autodelete = True

--- a/metricq_manager/manager.py
+++ b/metricq_manager/manager.py
@@ -167,18 +167,6 @@ class Manager(ManagementAgent):
             self.management_queue_name, durable=True, robust=True
         )
 
-        logger.info("creating rpc exchanges")
-        self._management_exchange = await self._management_channel.declare_exchange(
-            name=self._management_exchange_name,
-            type=aio_pika.ExchangeType.TOPIC,
-            durable=True,
-        )
-        self._management_broadcast_exchange = await self._management_channel.declare_exchange(
-            name=self._management_broadcast_exchange_name,
-            type=aio_pika.ExchangeType.FANOUT,
-            durable=True,
-        )
-
         await self.management_queue.bind(
             exchange=self._management_exchange, routing_key="#"
         )

--- a/metricq_manager/manager.py
+++ b/metricq_manager/manager.py
@@ -525,91 +525,10 @@ class Manager(ManagementAgent):
         limit=None,
         **body,
     ):
-        if format not in ("array", "object"):
-            raise AttributeError("unknown format requested: {}".format(format))
 
-        if infix is not None and prefix is not None:
-            raise AttributeError('cannot get_metrics with both "prefix" and "infix"')
-
-        selector_dict = dict()
-        if selector is not None:
-            if isinstance(selector, str):
-                selector_dict["_id"] = {"$regex": selector}
-            elif isinstance(selector, list):
-                if len(selector) < 1:
-                    raise ValueError("Empty selector list")
-                if len(selector) == 1:
-                    # That may possibly be faster.
-                    selector_dict["_id"] = selector[0]
-                else:
-                    selector_dict["_id"] = {"$in": selector}
-            else:
-                raise TypeError(
-                    "Invalid selector type: {}, supported: str, list", type(selector)
-                )
-        if historic is not None:
-            if not isinstance(historic, bool):
-                raise AttributeError(
-                    'invalid type for "historic" argument: should be bool, is {}'.format(
-                        type(historic)
-                    )
-                )
-
-        # TODO can this be unified without compromising performance?
-        # Does this even perform well?
-        # ALSO: Async :-[
-        if selector_dict:
-            if historic is not None:
-                selector_dict["historic"] = historic
-            if prefix is not None or infix is not None:
-                raise AttributeError(
-                    'cannot get_metrics with both "selector" and "prefix" or "infix".'
-                )
-            aiter = self.couchdb_db_metadata.find(selector_dict, limit=limit)
-            if format == "array":
-                metrics = [doc["_id"] async for doc in aiter]
-            elif format == "object":
-                metrics = {doc["_id"]: doc.data async for doc in aiter}
-
-        else:  # No selector dict, all *fix / historic filtering
-            request_limit = limit
-            if infix is None:
-                request_prefix = prefix
-                if historic is not None:
-                    endpoint = self.couchdb_db_metadata.view("index", "historic")
-                else:
-                    endpoint = self.couchdb_db_metadata.all_docs
-            else:
-                request_prefix = infix
-                # These views produce stupid duplicates thus we must filter ourselves and request more
-                # to get enough results. We assume for no more than 6 infix segments on average
-                if limit is not None:
-                    request_limit = 6 * limit
-                if historic is not None:
-                    endpoint = self.couchdb_db_metadata.view("components", "historic")
-                else:
-                    raise NotImplementedError(
-                        "non-historic infix lookup not yet supported"
-                    )
-            if format == "array":
-                metrics = [
-                    key
-                    async for key in endpoint.ids(
-                        prefix=request_prefix, limit=request_limit
-                    )
-                ]
-                if request_limit != limit:
-                    # Object of type islice is not JSON serializable m(
-                    metrics = list(islice(sorted(set(metrics)), limit))
-            elif format == "object":
-                metrics = {
-                    doc["_id"]: doc.data
-                    async for doc in endpoint.docs(
-                        prefix=request_prefix, limit=request_limit
-                    )
-                }
-                if request_limit != limit:
-                    metrics = dict(islice(sorted(metrics.items()), limit))
+        metrics = await self.get_metrics(
+            format, historic, selector, prefix, infix, limit
+        )
 
         return {"metrics": metrics}
 


### PR DESCRIPTION
Moves parts of `metricq-manager `to a new management baseclass `ManagementAgent` for use in `metricq-manager` and `metricq-wizard`. Depends on metricq/metricq#48