### PR TITLE
Improvements to database pre-declare script

### DIFF
--- a/metricq_manager/config_parser.py
+++ b/metricq_manager/config_parser.py
@@ -257,11 +257,49 @@ class ConfigParser:
             )
             return None
 
+    def quorum_max_in_memory_bytes(self) -> Optional[int]:
+        max_in_memory_bytes: Any = self.get(f"{self.role}-max-in-memory-bytes")
+        if max_in_memory_bytes is None:
+            return None
+        elif isinstance(max_in_memory_bytes, int):
+            if max_in_memory_bytes >= 0:
+                return max_in_memory_bytes
+            else:
+                logger.warning(
+                    "Client {!r} has negative queue bytes-in-memory limit (is {} bytes)",
+                    self.client_token,
+                    max_in_memory_bytes,
+                )
+                return None
+
+    def quorum_max_in_memory_length(self) -> Optional[int]:
+        max_in_memory_length: Any = self.get(f"{self.role}-max-in-memory-length")
+        if max_in_memory_length is None:
+            return None
+        elif isinstance(max_in_memory_length, int):
+            if max_in_memory_length >= 0:
+                return max_in_memory_length
+            else:
+                logger.warning(
+                    "Client {!r} has negative maximum number of in-memory messages (is {})",
+                    self.client_token,
+                    max_in_memory_length,
+                )
+                return None
+
     def quorum_arguments(self) -> Iterator[Tuple[str, Any]]:
         """An iterator over `key-value` pairs of arguments for queues of type
         :literal:`"quorum"`, as parsed from the configuration object.
         """
         yield ("x-queue-type", "quorum")
+
+        max_in_memory_length = self.quorum_max_in_memory_length()
+        if max_in_memory_length is not None:
+            yield ("x-max-in-memory-length", max_in_memory_length)
+
+        max_in_memory_bytes = self.quorum_max_in_memory_bytes()
+        if max_in_memory_bytes is not None:
+            yield ("x-max-in-memory-bytes", max_in_memory_bytes)
 
     def arguments(self) -> Iterator[Tuple[str, Any]]:
         """An iterator over `key-value` pairs of arguments for queues, as

--- a/tools/db-predeclare.py
+++ b/tools/db-predeclare.py
@@ -114,7 +114,11 @@ class MetricqDbPreregister(metricq.Agent):
                 f"/api/bindings/{vhost}/e/{exchange}/q/{queue}/", encoded=True
             )
         ) as response:
-            return [binding["routing_key"] for binding in await response.json()]
+            bindings_json = await response.json()
+            if not response.ok:
+                error = bindings_json.get("error")
+                raise RuntimeError(f"RabbitMQ API returned an error: {error}")
+            return [binding["routing_key"] for binding in bindings_json]
 
     async def fetch_bindings(
         self,

--- a/tools/db-predeclare.py
+++ b/tools/db-predeclare.py
@@ -69,7 +69,7 @@ class MetricqDbPreregister(metricq.Agent):
         self.http_api_url = (
             URL(server).with_scheme("https").with_port(None)
             if http_api_url is None
-            else http_api_url
+            else URL(http_api_url)
         )
         self.data_vhost = data_vhost
         self.data_exchange = data_exchange


### PR DESCRIPTION
The changes here make the following possible:

1. Declare database queues, but only create data bindings, omitting any history request bindings (`--no-history-bindings`)
2. Copy data/history bindings from another database that is currently online (`db-target:from=db-source`)

In total, this should allow us to create queues and bindings for a dummy database (`db-dummy`) that receives the same data as some other database (`db-very-important`), but does not answer any history requests:

```sh
$ db-predeclare --no-history-bindings db-dummy:from=db-very-important
```