### PR TITLE
Write a warning when a metric gets declared by a different source

### DIFF
--- a/metricq_manager/manager.py
+++ b/metricq_manager/manager.py
@@ -413,6 +413,11 @@ class Manager(Agent):
                     metrics_updated += 1
 
                 update_doc(doc, metrics[doc.id], update_date)
+
+                if "source" in doc and doc["source"]:
+                    logger.warn(
+                        f"Changing source for metric '{doc.id}' from {doc['source']} to {from_token}"
+                    )
                 doc["source"] = from_token
         end = time.time()
 


### PR DESCRIPTION
Fixes #23