### PR TITLE
Cleanup unused bindings for DB

### DIFF
--- a/metricq_manager/queue_manager.py
+++ b/metricq_manager/queue_manager.py
@@ -271,7 +271,7 @@ class QueueManager:
         client_token: str,
         queue_name: Optional[str],
         expires: Optional[Seconds] = None,
-        bindinds: Optional[List[Metric]] = None,
+        bindings: Optional[List[Metric]] = None,
     ) -> DataQueueName:
         """Declare a Sink's data queue and bind the requested metrics to it.
 
@@ -283,7 +283,7 @@ class QueueManager:
                 If given, the queue is declared with this name, reusing it if it already exists.
             expires:
                 The number of seconds after which the queue will be deleted once the Sink disconnects.
-            bindinds:
+            bindings:
                 An optional list of metrics names this Sink subscribes to.
                 These are bound to the newly declared data queue.
 
@@ -318,9 +318,9 @@ class QueueManager:
                 channel=channel,
             )
 
-            if bindinds:
+            if bindings:
                 await self._bind_metrics(
-                    metrics=bindinds,
+                    metrics=bindings,
                     queue=data_queue,
                     exchange=self.data_exchange,
                     channel=channel,
@@ -471,14 +471,14 @@ class QueueManager:
     async def transformer_declare_data_queue(
         self,
         transformer_token: str,
-        bindinds: Optional[List[Metric]] = None,
+        bindings: Optional[List[Metric]] = None,
     ) -> DataQueueName:
         """Declare a Transformer's data queue and bind the requested metrics to it.
 
         Args:
             transformer_token:
                 Token of the Transformer.
-            bindinds:
+            bindings:
                 An optional list of metrics to bind on this queue.
         """
         async with self.temporary_channel() as channel:
@@ -489,10 +489,10 @@ class QueueManager:
                 channel=channel,
             )
 
-            if bindinds:
+            if bindings:
                 # TODO Also unbind other metrics that are no longer relevant
                 await self._bind_metrics(
-                    metrics=bindinds,
+                    metrics=bindings,
                     queue=data_queue,
                     exchange=self.data_exchange,
                     channel=channel,
@@ -528,22 +528,22 @@ class QueueManager:
             async def declare_queue_and_bind(
                 display_name: str,
                 config: ConfigParser,
-                bindinds: Optional[List[Metric]],
+                bindings: Optional[List[Metric]],
                 channel: RobustChannel,
                 exchange: ExchangeName,
             ):
                 logger.info("Declaring {} for database {!r}", display_name, db_token)
                 queue = await self.declare_durable_queue(config=config, channel=channel)
 
-                if bindinds is not None:
+                if bindings is not None:
                     logger.info(
                         "Binding {} metric(s) to {} for database {!r}",
-                        len(bindinds),
+                        len(bindings),
                         display_name,
                         db_token,
                     )
                     await self._bind_metrics(
-                        metrics=bindinds,
+                        metrics=bindings,
                         queue=queue,
                         exchange=exchange,
                         channel=channel,
@@ -554,14 +554,14 @@ class QueueManager:
                 declare_queue_and_bind(
                     display_name="data queue",
                     config=data_config,
-                    bindinds=data_bindings,
+                    bindings=data_bindings,
                     channel=channel,
                     exchange=self.data_exchange,
                 ),
                 declare_queue_and_bind(
                     display_name="history request queue",
                     config=hreq_config,
-                    bindinds=history_bindings,
+                    bindings=history_bindings,
                     channel=channel,
                     exchange=self.history_exchange,
                 ),

--- a/metricq_manager/rabbitmq.py
+++ b/metricq_manager/rabbitmq.py
@@ -1,0 +1,72 @@
+# metricq
+# Copyright (C) 2021 ZIH, Technische Universitaet Dresden, Federal Republic of Germany
+#
+# All rights reserved.
+#
+# This file is part of metricq.
+#
+# metricq is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# metricq is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with metricq.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import List
+from urllib.parse import quote
+
+from aiohttp import BasicAuth, ClientSession
+from yarl import URL
+import metricq
+from metricq.logging import get_logger
+
+
+from .types import Metric
+
+logger = get_logger(__name__)
+
+
+class RabbitMQRestAPI:
+    def __init__(self, server: URL, data_vhost: str):
+        self.http_api_url = (
+            URL(server).with_scheme("https" if server.scheme == "amqps" else "http").with_port(15672 if server.port else None)
+        )
+
+        self.auth = (
+            BasicAuth(
+                login=self.http_api_url.user, password=self.http_api_url.password
+            )
+            if self.http_api_url.user and self.http_api_url.password
+            else None
+        )
+
+        self.data_vhost = data_vhost
+
+    def data_vhost_quoted(self) -> str:
+        return quote(self.data_vhost, safe="")
+
+    async def fetch_queue_bindings(
+        self, exchange: str, queue: str
+    ) -> List[Metric]:
+
+        vhost = self.data_vhost_quoted()
+        get_url = self.http_api_url.with_path(
+            f"/api/bindings/{vhost}/e/{exchange}/q/{queue}/", encoded=True
+        )
+        logger.info(
+            "Fetching queue bindings from {!r}",
+            get_url.with_user("***").with_password("***").human_repr(),
+        )
+        async with ClientSession(auth=self.auth) as http_session:
+            async with http_session.get(get_url) as response:
+                bindings_json = await response.json()
+                if not response.ok:
+                    error = bindings_json.get("error")
+                    raise RuntimeError(f"RabbitMQ API returned an error: {error}")
+                return [binding["routing_key"] for binding in bindings_json]

--- a/metricq_manager/types.py
+++ b/metricq_manager/types.py
@@ -1,0 +1,25 @@
+# metricq
+# Copyright (C) 2021 ZIH, Technische Universitaet Dresden, Federal Republic of Germany
+#
+# All rights reserved.
+#
+# This file is part of metricq.
+#
+# metricq is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# metricq is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with metricq.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
+
+
+Metric = str
+MetricList = Union[List[Metric], Dict[Metric, Dict[str, Any]]]


### PR DESCRIPTION
This patch tries to remove unused queue bindings, though we need to discuss some issues.

- Is it possible to reliably derive the RabbitMQ Rest API Url from the `managment_url`?
- Corner case: If a metric is removed from a database, but is still being actively published to MetricQ, message will end up in the queue, until, during the db.register, it gets eventually deleted. So, a db-hta might receive some, according to its current configuration, unexpected messages. 
- Corner case: The database needs to be restarted for this to take effect. I'm not sure whether this is a requirement from the db-hta or just a fuckup in this patch.

Fixes #21 